### PR TITLE
ログイン機能とログアウト機能の雛形を実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,18 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import "./App.css";
 import { Register } from "./components/Register";
 import { Login } from "./components/Login";
 import { MyPage } from "./components/MyPage";
-
+import "./App.css";
 
 function App() {
   return (
-    <>
-      <BrowserRouter>
-        <Routes>
-          <Route path={`/register/`} element={<Register />} />
-          <Route path={`/login/`} element={<Login />} />
-          <Route path={`/`} element={<MyPage />} />
-        </Routes>
-      </BrowserRouter>
-    </>
+    <BrowserRouter>
+      <Routes>
+        <Route path="register" element={<Register />} />
+        <Route path="login" element={<Login />} />
+        <Route path="/" element={<MyPage />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,23 +1,65 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import {
+  onAuthStateChanged,
+  User,
+  signInWithEmailAndPassword,
+} from "firebase/auth";
+import { auth } from "../../firebaseConfig";
+import { Navigate } from "react-router-dom";
 
 export const Login = () => {
-  const [loginEmail, setLoginEmail] = useState("");
-  const [loginPassword, setLoginPassword] = useState("");
+  const [loginEmail, setLoginEmail] = useState<string>("");
+  const [loginPassword, setLoginPassword] = useState<string>("");
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+      setUser(currentUser);
+      // ログイン済みの場合、マイページに遷移
+    });
+
+    return () => unsubscribe(); // クリーンアップ関数を返す
+  }, []);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    try {
+      await signInWithEmailAndPassword(auth, loginEmail, loginPassword);
+    } catch (error) {
+      alert(`${error}`);
+    }
+  };
 
   return (
     <>
-      <h1>ログインページ</h1>
-      <form>
-        <div>
-          <label>メールアドレス</label>
-          <input name="email" type="email" value={loginEmail} onChange={(e) => setLoginEmail(e.target.value)}/>
-        </div>
-        <div>
-          <label>パスワード</label>
-          <input name="password" type="password" value={loginPassword} onChange={(e) => setLoginPassword(e.target.value)}/>
-        </div>
-        <button>ログイン</button>
-      </form>
+      {user ? (
+        <Navigate to={"/"} />
+      ) : (
+        <>
+          <h1>ログインページ</h1>
+          <form onSubmit={handleSubmit}>
+            <div>
+              <label>メールアドレス</label>
+              <input
+                name="email"
+                type="email"
+                value={loginEmail}
+                onChange={(e) => setLoginEmail(e.target.value)}
+              />
+            </div>
+            <div>
+              <label>パスワード</label>
+              <input
+                name="password"
+                type="password"
+                value={loginPassword}
+                onChange={(e) => setLoginPassword(e.target.value)}
+              />
+            </div>
+            <button>ログイン</button>
+          </form>
+        </>
+      )}
     </>
   );
 };

--- a/src/components/MyPage.tsx
+++ b/src/components/MyPage.tsx
@@ -1,8 +1,30 @@
+import { useState, useEffect } from "react";
+import { onAuthStateChanged, User, signOut } from "firebase/auth";
+import { auth } from "../../firebaseConfig";
+import { useNavigate } from "react-router-dom";
+
 export const MyPage = () => {
+  const [user, setUser] = useState<User | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+      setUser(currentUser); // ユーザー情報を更新
+    });
+
+    return () => unsubscribe(); // クリーンアップ関数を返す
+  }, []);
+
+  const logout = async () => {
+    await signOut(auth);
+    navigate("/login");
+  };
+
   return (
     <>
       <h1>マイページ</h1>
-      <button>ログアウト</button>
+      <p>{user?.email}</p>
+      <button onClick={logout}>ログアウト</button>
     </>
   );
 };

--- a/src/components/Register.tsx
+++ b/src/components/Register.tsx
@@ -1,14 +1,28 @@
-import { useState } from "react";
-import { createUserWithEmailAndPassword } from "firebase/auth";
+import { useState, useEffect } from "react";
+import {
+  createUserWithEmailAndPassword,
+  onAuthStateChanged,
+  User,
+} from "firebase/auth";
 import { auth } from "../../firebaseConfig";
+import { Navigate } from "react-router-dom";
 
 export const Register = () => {
   const [registerEmail, setRegisterEmail] = useState<string>("");
   const [registerPassword, setRegisterPassword] = useState<string>("");
+  const [user, setUser] = useState<User | null>(null); // 初期値を null にする
 
-  const handoleSubmit = async (event: React.FormEvent) => {
-    //React.FormEventはフォームイベントオブジェクトの型で、フォームイベントが発生すると生成され、イベントオブジェクトを使用してデフォルトのフォーム送信動作を防ぐことができる
-    event.preventDefault(); //これがないと関数「handleSubmit」が実行されたときにブラウザがリロードされてしまう
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+      setUser(currentUser); // ユーザー情報を更新
+    });
+
+    return () => unsubscribe(); // クリーンアップ関数を返す
+  }, []);
+
+  // フォーム送信時の処理
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
     try {
       await createUserWithEmailAndPassword(
         auth,
@@ -22,8 +36,9 @@ export const Register = () => {
 
   return (
     <>
-      <h1>新規登録</h1>
-      <form onSubmit={handoleSubmit}>
+    { user ? ( <Navigate to={"/"} /> ) : (<>
+    <h1>新規登録</h1>
+      <form onSubmit={handleSubmit}>
         <div>
           <label>メールアドレス</label>
           <input
@@ -43,7 +58,7 @@ export const Register = () => {
           />
         </div>
         <button>登録する</button>
-      </form>
+      </form></>) }
     </>
   );
 };


### PR DESCRIPTION
【実装内容】
・新規アカウント登録したらFirebaseにデータがpostされ、マイページに遷移
・マイページにあるログアウトボタンを押したらログイン画面に遷移するようnavigate
・ログイン画面はアカウントがあるユーザーがログインすればマイページに遷移
（userがnullであればアカウントがないと判断されエラーになる仕組み）
【課題】
・RegisterとLoginコンポーネントで似たような記述があるので、リファクタリングが必要
・新規登録はヘッダーのグローバルナビに実装したい